### PR TITLE
Prints FQDN to log instead of IP when the IP doesn't exist

### DIFF
--- a/noip-rfc2136.py
+++ b/noip-rfc2136.py
@@ -77,7 +77,7 @@ def GetCurrentIP(fqdn):
             dns.resolver.NoAnswer,
             KeyError):
         # If it's not in DNS, return nothing
-        logger.debug('No IP in DNS for ' + str(current_ip))
+        logger.debug('No IP in DNS for ' + str(fqdn))
         current_ip = None
 
     return current_ip


### PR DESCRIPTION
Fixes #6 by printing the FQDN to the log rather than the IP