### PR TITLE
fix deprecations

### DIFF
--- a/noip-rfc2136.py
+++ b/noip-rfc2136.py
@@ -135,7 +135,7 @@ def GetCurrentIP(fqdn):
     curent_ip = None
     logger.debug('Querying IP for ' + str(fqdn) + ' from ' + str(config.dns.nameserver))
     try:
-        answer = resolver.query(fqdn, 'A')
+        answer = resolver.resolve(fqdn, 'A')
         current_ip = answer[0].to_text()
         status = 'OK'
         logger.debug('Got current IP: ' + str(current_ip))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiohttp>=3.01
 aiohttp-basicauth-middleware==1.1.2
 colorlog
-dnspython==1.16.0
+dnspython==2.2.1
 pyyaml


### PR DESCRIPTION
dnspython==1.16.0 uses base64.decodestring(), which has been removed in python3.9 for base64.decodebytes().

dns.resolver.Resolver.query() was deprecated in favor of .resolve().