### PR TITLE
Add /nic/update endpoint to make it compatible with dyndns2 protocol

### DIFF
--- a/noip-rfc2136.py
+++ b/noip-rfc2136.py
@@ -349,6 +349,7 @@ def main():
 
     app = web.Application()
     app.add_routes([web.get('/update', UpdateReq)])
+    app.add_routes([web.get('/nic/update', UpdateReq)])
     if config.auth.enabled:
         app.middlewares.append(
             basic_auth_middleware(


### PR DESCRIPTION
The app's only endpoint is` /update` which is a bit confusing reading the documentation and does not conform to noip/dyndns2 protocol which uses instead `/nic/update`.
I suggest adding `/nic/update` as a new endpoint to not break compatibility with existing deployments.