### PR TITLE
Enable the use of hostname instead of IP for the nameserver

### DIFF
--- a/noip-rfc2136.py
+++ b/noip-rfc2136.py
@@ -272,7 +272,7 @@ def build_conf(config_file):
 
     config = AppConfig(config_file)
     # Update config from environment variables if present
-    config.dns.nameserver = os.environ.get('NOIP_RFC2136_DNS_NAMESERVER', config.dns.nameserver)
+    config.dns.nameserver = socket.gethostbyname(os.environ.get('NOIP_RFC2136_DNS_NAMESERVER', config.dns.nameserver))
     config.dns.zone = os.environ.get('NOIP_RFC2136_DNS_ZONE', config.dns.zone)
     config.dns.ttl = os.environ.get('NOIP_RFC2136_DNS_TTL', config.dns.ttl)
     config.dns.create_enabled = os.environ.get('NOIP_RFC2136_DNS_CREATE_ENABLED', config.dns.create_enabled)


### PR DESCRIPTION
I'm suggesting another minor change to be able to define the nameserver in the config by its hostname instead of its IP address.
If given an IP address, `socket.gethostbyname` will return that IP, so this change doesn't break the existing behaviour.